### PR TITLE
Bucket Splitting

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -25,6 +25,7 @@ func (b *bucket) Get(key string, dest interface{}) error {
 
 func (b *bucket) Load(rootPath, id string) error {
 	b.id = id
+	b.objects = nil
 
 	bucketPath, err := b.path(rootPath)
 	if err != nil {
@@ -73,6 +74,38 @@ func (b *bucket) Save(rootPath string) error {
 
 	encoder := json.NewEncoder(file)
 	return encoder.Encode(b.objects)
+}
+
+func (b *bucket) Split(s *Store) error {
+	bucketPath, err := b.path(s.rootPath)
+	if err != nil {
+		return err
+	}
+
+	os.Rename(bucketPath, bucketPath+".swp")
+
+	err = os.Mkdir(bucketPath, os.FileMode(0700))
+	if err != nil {
+		os.Rename(bucketPath+".swp", bucketPath)
+		return err
+	}
+
+	for key, encodedValue := range b.objects {
+		bucket, err := s.bucketForKey(key)
+		if err == nil {
+			bucket.objects[key] = encodedValue
+			err = bucket.Save(s.rootPath)
+		}
+
+		if err != nil {
+			os.RemoveAll(bucketPath)
+			os.Rename(bucketPath+".swp", bucketPath)
+			return err
+		}
+	}
+
+	os.Remove(bucketPath + ".swp")
+	return nil
 }
 
 func (b *bucket) path(rootPath string) (string, error) {

--- a/bucket.go
+++ b/bucket.go
@@ -45,6 +45,10 @@ func (b *bucket) Load(rootPath, id string) error {
 	return decoder.Decode(&b.objects)
 }
 
+func (b *bucket) ObjectCount() int {
+	return len(b.objects)
+}
+
 func (b *bucket) Put(key string, value interface{}) error {
 	encodedValue, err := json.Marshal(value)
 	if err != nil {

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -30,6 +30,26 @@ func TestBucketLoadSucceedsWhenFileDoesNotExist(t *testing.T) {
 	}
 }
 
+func TestBucketObjectCount(t *testing.T) {
+	var b = newBucket("bucket")
+
+	if expected, count := 0, b.ObjectCount(); expected != count {
+		t.Errorf("Expected %d objects but got %d", expected, count)
+	}
+
+	b.Put("a", 1)
+
+	if expected, count := 1, b.ObjectCount(); expected != count {
+		t.Errorf("Expected %d objects but got %d", expected, count)
+	}
+
+	b.Put("b", 2)
+
+	if expected, count := 2, b.ObjectCount(); expected != count {
+		t.Errorf("Expected %d objects but got %d", expected, count)
+	}
+}
+
 func TestBucketPathFindsFirstNonDirectory(t *testing.T) {
 	var rootPath, err = ioutil.TempDir("", "keva-bucket-test")
 	if err != nil {

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -123,3 +123,74 @@ func TestBucketRoundTrip(t *testing.T) {
 		t.Errorf("Expected value 'red' but got %s", value.Colour)
 	}
 }
+
+func TestBucketSplitPushesObjectsToSubdirectories(t *testing.T) {
+	var rootPath, err = ioutil.TempDir("", "keva-bucket-test")
+	if err != nil {
+		t.Fatalf("Error creating temporary location for bucket: %v", err)
+	}
+
+	defer os.RemoveAll(rootPath)
+
+	var s = NewStore(rootPath)
+
+	var b bucket
+	err = b.Load(rootPath, s.bucketIdForKey("aabb"))
+	if err != nil {
+		t.Fatalf("Error loading bucket: %v", err)
+	}
+
+	b.Put("aabb", "value1")
+	b.Put("aacc", "value2")
+	b.Save(rootPath)
+
+	err = b.Split(s)
+	if err != nil {
+		t.Fatalf("Error splitting bucket: %v", err)
+	}
+
+	// Bucket with original ID should still contain first value
+
+	err = b.Load(rootPath, s.bucketIdForKey("aabb"))
+	if err != nil {
+		t.Fatalf("Error loading bucket: %v", err)
+	}
+	if count := b.ObjectCount(); count != 1 {
+		t.Errorf("Expected bucket to contain 1 object but got %d", count)
+	}
+
+	var value string
+
+	err = b.Get("aabb", &value)
+	if err != nil {
+		t.Errorf("Error retrieving value from bucket: %v", err)
+	}
+	if value != "value1" {
+		t.Errorf("Retrieved value '%s' but expected 'value1'", value)
+	}
+
+	// Second value should no longer be in this bucket
+
+	err = b.Get("aacc", &value)
+	if err == nil {
+		t.Errorf("Expected error but got value '%v'", value)
+	}
+
+	// Second value should have been split into another bucket
+
+	err = b.Load(rootPath, s.bucketIdForKey("aacc"))
+	if err != nil {
+		t.Fatalf("Error loading bucket: %v", err)
+	}
+	if count := b.ObjectCount(); count != 1 {
+		t.Errorf("Expected bucket to contain 1 object but got %d", count)
+	}
+
+	err = b.Get("aacc", &value)
+	if err != nil {
+		t.Errorf("Error retrieving value from bucket: %v", err)
+	}
+	if value != "value2" {
+		t.Errorf("Retrieved value '%s' but expected 'value2'", value)
+	}
+}

--- a/store.go
+++ b/store.go
@@ -37,6 +37,10 @@ func (s *Store) Put(key string, value interface{}) error {
 		return err
 	}
 
+	if bucket.ObjectCount() > s.maxObjectsPerBucket {
+		return bucket.Split(s)
+	}
+
 	return bucket.Save(s.rootPath)
 }
 


### PR DESCRIPTION
We want to support dynamically adapting to datasets of different sizes. As more objects are added, we can split the buckets to keep the number of objects in each bucket relatively level. This avoids situations where a bucket can come to contain a very large number of objects, making it inefficient to access.
